### PR TITLE
i18n Transform: transform attempts to translate @labelPosition argument

### DIFF
--- a/lib/helpers/getArgumentsToTranslate.js
+++ b/lib/helpers/getArgumentsToTranslate.js
@@ -470,7 +470,6 @@ let componentsToTranslate = [
   {
     "name": "LunaForm::LunaFormGroup",
     "arguments": [
-      "@labelPosition",
       "@name"
     ]
   },

--- a/test/unit/labelPosition.js
+++ b/test/unit/labelPosition.js
@@ -1,0 +1,15 @@
+const testCase = require("../helpers/test-case");
+
+describe("Exclude labelPosition argument", function () {
+  testCase({
+    name: "labelPosition shouldn't be translated",
+    input: `
+    <LunaForm::LunaFormGroup @labelPosition="horizontal" @name="Description" class="flex-3" as |formGroup|>
+    </LunaForm::LunaFormGroup>
+    `,
+    output: `
+    <LunaForm::LunaFormGroup @labelPosition="horizontal" @name={{format-message "Description"}} class="flex-3" as |formGroup|>
+    </LunaForm::LunaFormGroup>
+    `,
+  });
+});


### PR DESCRIPTION
Given:

```hbs
<LunaForm::LunaFormGroup @labelPosition="horizontal" @name="Description" class="flex-3" as |formGroup|>
```

Current:

```hbs
<LunaForm::LunaFormGroup @labelPosition={{format-message "horizontal"}} @name={{format-message "Description"}} class="flex-3" as |formGroup|>
```

Expected:

```hbs
<LunaForm::LunaFormGroup @labelPosition="horizontal" @name={{format-message "Description"}} class="flex-3" as |formGroup|>
```