### PR TITLE
Escape single quote

### DIFF
--- a/lib/helpers/serialize.js
+++ b/lib/helpers/serialize.js
@@ -5,12 +5,12 @@ const templateRecast = require('ember-template-recast');
 module.exports = function serialize(node) {
     if (node.type === 'StringLiteral') {
         return {
-            text: node.value.replace(/\}/g, '\'}').replace(/\{/g, '\'{'),
+            text: node.value.replace(/\}/g, '\'}').replace(/'/g,"''").replace(/\{/g, '\'{'),
             values: {}
         };
     } else if (node.type === 'TextNode') {
         return {
-            text: node.chars.replace(/\s+/g, ' ').replace(/\}/g, '\'}').replace(/\{/g, '\'{'),
+            text: node.chars.replace(/\s+/g, ' ').replace(/'/g,"''").replace(/\}/g, '\'}').replace(/\{/g, '\'{'),
             values: {}
         };
     } else if (node.type === 'MustacheStatement') {

--- a/test/unit/singleQuote.js
+++ b/test/unit/singleQuote.js
@@ -1,0 +1,13 @@
+const testCase = require("../helpers/test-case");
+
+describe("Single quote", function () {
+  testCase({
+    name: "Single quote should be escaped",
+    input: `
+      <span>I'm a span. Aren't tests awesome?</span>
+    `,
+    output: `
+      <span>{{format-message "I''m a span. Aren''t tests awesome?"}}</span>
+    `,
+  });
+});


### PR DESCRIPTION
The single quote is a special character and should be escaped with a single quote.

Single quote in the following text
```
<span>Don't know</span>
```

should be replaced as follow:
```
<span>{{format-message "Don''t know}}</span>
```