### PR TITLE
Sox 17589 i18n: Transform pluralize in js files

### DIFF
--- a/lib/helpers/isExcludedFunctionCall.js
+++ b/lib/helpers/isExcludedFunctionCall.js
@@ -2,7 +2,6 @@ const excludedFunctions = [
   ".on",
   ".indexOf",
   "$",
-  "pluralize",
   ".format",
   "assert",
   "console.warn",

--- a/lib/jsshift.js
+++ b/lib/jsshift.js
@@ -2,10 +2,19 @@ const babylon = require('@babel/parser');
 const convertToKey = require('./helpers/convertToKey');
 const isExcludedFunctionCall = require('./helpers/isExcludedFunctionCall');
 const isExcludedVariable = require('./helpers/isExcludedVariable');
+const pluralize = require("pluralize");
+
+function isPlural(text){
+  return text.includes('plural,') && text.includes('=1') && text.includes('=0') && text.includes('other');
+}
 
 function isText(text) {
   if (!text || !text.match) {
     return false;
+  }
+
+  if(isPlural(text)){
+    return true;
   }
 
   //exclude specific texts
@@ -242,11 +251,12 @@ function createFormatMessageExpression(j, node, excludeThis) {
   if (node.value) {
     text = node.value;
   } else {
+    let pluralKey = node.quasis.find(q=>isPlural(q.value.raw))?'count':'';
     for (let i = 0; i < node.expressions.length; i++) {
       let key = convertToKey(j(node.expressions[i]).toSource());
-      text += node.quasis[i].value.raw + `{${key}}`;
+      text += node.quasis[i].value.raw + (pluralKey || `{${key}}`);
       if (!properties.find(p => p.key.name === key)) {
-        properties.push(j.property('init', j.identifier(key), node.expressions[i]));
+        properties.push(j.property('init', j.identifier(pluralKey||key), node.expressions[i]));
       }
     }
     text += node.quasis[node.quasis.length - 1].value.raw;
@@ -454,11 +464,79 @@ function createTransform(j, ast, onSomethingChanged) {
   }
 }
 
+function mergePluralToTemplateString(path){
+  for(let i=0; i<path.parent.node.expressions.length; i++){
+    if(path.parent.node.expressions[i]===path.node){
+      // find pluralize templateString in parent
+      path.parent.node.quasis[i].value.raw += path.node.quasis[0].value.raw;
+      path.parent.node.quasis[i].value.cooked = path.parent.node.quasis[i].value.raw;
+
+      path.parent.node.quasis[i+1].value.raw = path.node.quasis[1].value.raw + path.parent.node.quasis[i+1].value.raw;
+      path.parent.node.quasis[i+1].value.cooked = path.parent.node.quasis[i+1].value.raw;
+
+      path.parent.node.expressions[i] = path.node.expressions[0];
+      break;
+    }
+  }
+}
+
+function pluralizeReplaceWithTemplateString(j,path) {
+  const text = path.node.arguments[0].value;
+  const withoutCount =
+    path.node.arguments[2]?.properties?.find(
+      (p) => p.key.name === "withoutCount"
+    )?.value.value ?? false;
+  const zeroText = (withoutCount ? "" : "no ") + pluralize(text, 0);
+  const oneText = (withoutCount ? "" : "one ") + pluralize(text, 1);
+  const otherText = (withoutCount ? "" : "# ") + pluralize(text, 2);
+  j(path).replaceWith(
+    j.templateLiteral(
+      [
+        j.templateElement({ raw: "{", cooked: "{" }, false),
+        j.templateElement(
+          {
+            raw: `, plural, =0 {${zeroText}} =1 {${oneText}} other {${otherText}}}`,
+            cooked: `, plural, =0 {${zeroText}} =1 {${oneText}} other {${otherText}}}`,
+          },
+          true
+        ),
+      ],
+      [path.node.arguments.length > 1 ? path.node.arguments[1] : j.literal(2)]
+    )
+  );
+
+  if (path.parent.node.type === "TemplateLiteral") {
+    mergePluralToTemplateString(path);
+  }
+}
+
 function transformer(file, api) {
   const j = api.jscodeshift;
   let ast = j(file.source);
   let somethingChanged = false
 
+  const replacedPluralize = ast
+    .find(j.CallExpression, {
+      callee: { name: "pluralize" },
+      arguments: [{type: 'StringLiteral'}],
+    })
+    .forEach((path) => {
+      if(path.node.arguments.length<=1){
+        const text = path.node.arguments[0].value;
+        const otherText = pluralize(text, 2);
+        j(path).replaceWith(j.stringLiteral(otherText));
+      }else{
+        pluralizeReplaceWithTemplateString(j, path);
+      }
+    })
+    .toSource({
+      quote: "single",
+      trailingComma: true,
+      useTabs: true,
+      reuseWhitespace: false,
+    });
+
+    ast = j(replacedPluralize);
   const replacedTexts = ast
     .find(j.Literal)
     .forEach(createTransform(j, ast, () => somethingChanged = true))

--- a/test/codeshift-fixtures/function.input.js
+++ b/test/codeshift-fixtures/function.input.js
@@ -11,7 +11,6 @@ function getSomething2(someArg, container) {
   console.log('Nice Message in console');
   aaa.on('Nice Message');
   aaa.indexOf('Nice Message');
-  pluralize('Nice Message');
   aaa.format('Nice Message');
   assert('Nice Message');
   console.warn('Nice Message');

--- a/test/codeshift-fixtures/function.output.js
+++ b/test/codeshift-fixtures/function.output.js
@@ -18,7 +18,6 @@ function getSomething2(someArg, container) {
   console.log('Nice Message in console');
   aaa.on('Nice Message');
   aaa.indexOf('Nice Message');
-  pluralize('Nice Message');
   aaa.format('Nice Message');
   assert('Nice Message');
   console.warn('Nice Message');

--- a/test/codeshift-fixtures/pluralize.input.js
+++ b/test/codeshift-fixtures/pluralize.input.js
@@ -1,0 +1,17 @@
+import { pluralize } from 'ember-inflector';
+import Component from '@ember/component';
+
+export default Component.extend({
+  init() {
+    const a = pluralize('Task');
+    const b = pluralize('Task', this.count);
+    const c = pluralize('Task', this.count, { withoutCount: true });
+    const d = `My name is Stan. I have got nice ${pluralize(
+      'Task',
+      this.count,
+      {
+        withoutCount: true,
+      }
+    )}.`;
+  },
+});

--- a/test/codeshift-fixtures/pluralize.output.js
+++ b/test/codeshift-fixtures/pluralize.output.js
@@ -1,0 +1,30 @@
+import { inject as service } from '@ember/service';
+import { pluralize } from 'ember-inflector';
+import Component from '@ember/component';
+
+export default Component.extend({
+  intl: service('intl'),
+  init() {
+    const a = this.intl.formatMessage({
+      defaultMessage: 'Tasks',
+    });
+
+    const b = this.intl.formatMessage({
+        defaultMessage: '{count, plural, =0 {no Tasks} =1 {one Task} other {# Tasks}}',
+    }, {
+        count: this.count,
+    });
+
+    const c = this.intl.formatMessage({
+        defaultMessage: '{count, plural, =0 {Tasks} =1 {Task} other {Tasks}}',
+    }, {
+        count: this.count,
+    });
+
+    const d = this.intl.formatMessage({
+        defaultMessage: 'My name is Stan. I have got nice {count, plural, =0 {Tasks} =1 {Task} other {Tasks}}.',
+    }, {
+        count: this.count,
+    });
+  },
+});


### PR DESCRIPTION
Transform pluralize in js files to format message.

**Before:**
```
    const a = pluralize('Task');
    const b = pluralize('Task', this.count);
    const c = pluralize('Task', this.count, { withoutCount: true });
    const d = `My name is Stan. I have got nice ${pluralize(
      'Task',
      this.count,
      {
        withoutCount: true,
      }
    )}.`;
```


**After:**
```
    const a = this.intl.formatMessage({
      defaultMessage: 'Tasks',
    });

    const b = this.intl.formatMessage({
        defaultMessage: '{count, plural, =0 {no Tasks} =1 {one Task} other {# Tasks}}',
    }, {
        count: this.count,
    });

    const c = this.intl.formatMessage({
        defaultMessage: '{count, plural, =0 {Tasks} =1 {Task} other {Tasks}}',
    }, {
        count: this.count,
    });

    const d = this.intl.formatMessage({
        defaultMessage: 'My name is Stan. I have got nice {count, plural, =0 {Tasks} =1 {Task} other {Tasks}}.',
    }, {
        count: this.count,
    });
```