### PR TITLE
Add comments above every auditboard-icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,37 @@
-Intl Template Transform
-==============================================================================
+# Intl Template Transform
 
-What it does?
-------------------------------------------------------------------------------
+## What it does?
+
 This repo provides an AST transform to convert
 
+## icon-transform.js
 
+There is icon-transform.js to add no-bare-strings above auditboard-icons
 
-Compatibility
-------------------------------------------------------------------------------
+```
+{{! template-lint-disable no-bare-strings }}
+{{! TODO: non translatable icon }}
+<i class="auditboard-icons">
+  close
+</i>
+```
 
-* Node.js v14 or above
+### How to run icon-transform.js
 
+- run icon-transform.js
+- run format hbs files
 
-Installation
-------------------------------------------------------------------------------
+```
+npx ember-template-recast path-to-file-or-directory -t path-to/icon-transform.js
+npm run format:hbs
+```
 
+## Compatibility
 
+- Node.js v14 or above
 
+## Installation
 
-License
-------------------------------------------------------------------------------
+## License
 
 This project is licensed under the [MIT License](LICENSE.md).

--- a/lib/icon-transform.js
+++ b/lib/icon-transform.js
@@ -1,0 +1,68 @@
+function descExist(node, parentNode) {
+  let children = [];
+  if (parentNode.type === "Template") {
+    children = parentNode.body;
+  } else if (parentNode.type === "ElementNode") {
+    children = parentNode.children;
+  }
+
+  const index = children.indexOf(node);
+  if (children[index - 1].type === "MustacheCommentStatement") {
+    return true;
+  }
+
+  if (
+    children[index - 2] &&
+    children[index - 2].type === "MustacheCommentStatement"
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+function createComment(comment) {
+  return {
+    type: "MustacheCommentStatement",
+    value: comment,
+  };
+}
+function createText(text) {
+  return {
+    type: "TextNode",
+    chars: text,
+  };
+}
+
+function isAuditboardIcon(node) {
+  return (
+    node.tag === "i" &&
+    node.attributes.find(
+      (a) =>
+        a.name === "class" &&
+        a.value.chars.split(" ").includes("auditboard-icons")
+    )
+  );
+}
+
+module.exports = function () {
+  let lastLoc = null;
+  return {
+    ElementNode(node, path) {
+      if (
+        isAuditboardIcon(node) &&
+        lastLoc != node.loc &&
+        !descExist(node, path.parent.node)
+      ) {
+        lastLoc = node.loc;
+        return [
+          createComment(" template-lint-disable no-bare-strings "),
+          createText("\n"),
+          createComment(" TODO: non translatable icon "),
+          createText("\n"),
+          node,
+        ];
+      }
+    },
+  };
+};


### PR DESCRIPTION
Create AST transform to add the following comments above every auditboard-icon in hbs files

Before
```
<i
data-qid="bulk-edit-close-btn"
class="auditboard-icons">
  close
</i>
```


After

```
{{! template-lint-disable no-bare-strings }}
{{! TODO: non translatable icon }}
<i
data-qid="bulk-edit-close-btn"
class="auditboard-icons">
  close
</i>
```

# How to run it
1 run icon-transform.js
2 run format hbs files
```
npx ember-template-recast path-to-file-or-directory -t path-to/icon-transform.js
npm run format:hbs
```