### PR TITLE
Pluralize arguments fix

### DIFF
--- a/lib/helpers/getArgumentsToTranslate.js
+++ b/lib/helpers/getArgumentsToTranslate.js
@@ -65,7 +65,7 @@ let componentsToTranslate = [
   },
   {
     name: 'Datatables::DatatableButtonBulkDestroy',
-    arguments: ['@label'],
+    arguments: ['@label', '@tooltip'],
   },
   {
     name: 'Datatables::DatatableButtonBulkDestroyHasmany',

--- a/lib/helpers/serialize.js
+++ b/lib/helpers/serialize.js
@@ -9,7 +9,7 @@ function serializePluralize(node) {
     const withoutCount = node.hash.pairs.find((p) => p.key === 'without-count')
       ?.value.value;
     const zeroText = (withoutCount ? '' : 'no ') + pluralize(text, 0);
-    const oneText = (withoutCount ? '' : 'one ') + pluralize(text, 1);
+    const oneText = (withoutCount ? '' : '# ') + pluralize(text, 1);
     const otherText = (withoutCount ? '' : '# ') + pluralize(text, 2);
     return {
       text: `{count, plural, =0 {${zeroText}} =1 {${oneText}} other {${otherText}}}`,

--- a/lib/jsshift.js
+++ b/lib/jsshift.js
@@ -617,7 +617,7 @@ function pluralizeReplaceWithTemplateString(j, path) {
       (p) => p.key.name === 'withoutCount'
     )?.value.value ?? false;
   const zeroText = (withoutCount ? '' : 'no ') + pluralize(text, 0);
-  const oneText = (withoutCount ? '' : 'one ') + pluralize(text, 1);
+  const oneText = (withoutCount ? '' : '# ') + pluralize(text, 1);
   const otherText = (withoutCount ? '' : '# ') + pluralize(text, 2);
   j(path).replaceWith(
     j.templateLiteral(

--- a/lib/jsshift.js
+++ b/lib/jsshift.js
@@ -611,7 +611,7 @@ function mergePluralToTemplateString(path) {
 }
 
 function pluralizeReplaceWithTemplateString(j, path) {
-  const text = path.node.arguments[0].value;
+  const text = path.node.arguments[1].value;
   const withoutCount =
     path.node.arguments[2]?.properties?.find(
       (p) => p.key.name === 'withoutCount'
@@ -631,7 +631,7 @@ function pluralizeReplaceWithTemplateString(j, path) {
           true
         ),
       ],
-      [path.node.arguments.length > 1 ? path.node.arguments[1] : j.literal(2)]
+      [path.node.arguments.length > 1 ? path.node.arguments[0] : j.literal(2)]
     )
   );
 
@@ -648,15 +648,18 @@ function transformer(file, api) {
   const replacedPluralize = ast
     .find(j.CallExpression, {
       callee: { name: 'pluralize' },
-      arguments: [{ type: 'StringLiteral' }],
     })
     .forEach((path) => {
       if (path.node.arguments.length <= 1) {
-        const text = path.node.arguments[0].value;
-        const otherText = pluralize(text, 2);
-        j(path).replaceWith(j.stringLiteral(otherText));
+        if (path.node.arguments[0].type === 'StringLiteral') {
+          const text = path.node.arguments[0].value;
+          const otherText = pluralize(text, 2);
+          j(path).replaceWith(j.stringLiteral(otherText));
+        }
       } else {
-        pluralizeReplaceWithTemplateString(j, path);
+        if (path.node.arguments[1].type === 'StringLiteral') {
+          pluralizeReplaceWithTemplateString(j, path);
+        }
       }
     })
     .toSource({

--- a/test/codeshift-fixtures/pluralize.input.js
+++ b/test/codeshift-fixtures/pluralize.input.js
@@ -4,11 +4,11 @@ import Component from '@ember/component';
 export default Component.extend({
   init() {
     const a = pluralize('Task');
-    const b = pluralize('Task', this.count);
-    const c = pluralize('Task', this.count, { withoutCount: true });
+    const b = pluralize(this.count, 'Task');
+    const c = pluralize(this.count, 'Task', { withoutCount: true });
     const d = `My name is Stan. I have got nice ${pluralize(
-      'Task',
       this.count,
+      'Task',
       {
         withoutCount: true,
       }

--- a/test/codeshift-fixtures/pluralize.output.js
+++ b/test/codeshift-fixtures/pluralize.output.js
@@ -10,7 +10,7 @@ export default Component.extend({
     });
 
     const b = this.intl.formatMessage({
-        defaultMessage: '{count, plural, =0 {no Tasks} =1 {one Task} other {# Tasks}}',
+        defaultMessage: '{count, plural, =0 {no Tasks} =1 {# Task} other {# Tasks}}',
     }, {
         count: this.count,
     });

--- a/test/unit/pluralize.js
+++ b/test/unit/pluralize.js
@@ -7,7 +7,7 @@ describe('Translate pluralize', function () {
     Reopen {{pluralize this.selectedCount "Task" without-count=false}}
     `,
     output: `
-    {{format-message "Reopen {count, plural, =0 {no Tasks} =1 {one Task} other {# Tasks}}" count=this.selectedCount}}
+    {{format-message "Reopen {count, plural, =0 {no Tasks} =1 {# Task} other {# Tasks}}" count=this.selectedCount}}
     `,
   });
 
@@ -17,7 +17,7 @@ describe('Translate pluralize', function () {
     Reopen {{pluralize this.selectedCount "Task"}}
     `,
     output: `
-    {{format-message "Reopen {count, plural, =0 {no Tasks} =1 {one Task} other {# Tasks}}" count=this.selectedCount}}
+    {{format-message "Reopen {count, plural, =0 {no Tasks} =1 {# Task} other {# Tasks}}" count=this.selectedCount}}
     `,
   });
 


### PR DESCRIPTION
1. Pluralize in js files is not transformed correctly, because there is a bug in transform. It expects arguments to the pluralize function in the wrong order.
2. There is a test in auditboard-forntend which expects result of pluralize to be "1 Task" instead of "one Task"
3. tooltip argument of Datatables::DatatableButtonBulkDestroy isn't translated.

**Requirement**
1. Fix argument position in the pluralize function in lib/jsshift.js transform file.
2. Transform pluralize(count, "Task") to "{count, plural, =0 {no Tasks} =1 {# Task} other {# Tasks}}" so the result will be "1 Task" when count is 1.
3. Add tooltip to lib/helpers/getArgumentsToTranslate.js so it will be translated.